### PR TITLE
Feature/generalize character selection

### DIFF
--- a/ahgl/api/admin.py
+++ b/ahgl/api/admin.py
@@ -5,7 +5,7 @@ from django.db.models.fields.related import RelatedField
 from django.contrib.admin.actions import delete_selected
 from django.utils import timezone
 
-from .models import Game, CarouselItem, Channel
+from .models import Game, CarouselItem, Channel, Character
 from profiles.models import Team, TeamMembership
 
 from tinymce.widgets import TinyMCE
@@ -20,9 +20,12 @@ class ChannelInline(admin.TabularInline):
         self.parent = obj
         return super(ChannelInline, self).get_formset(request, obj=obj, **kwargs)
 
+class CharacterInline(admin.TabularInline):
+    model = Character
+
 class GameAdmin(admin.ModelAdmin):
     list_display = ('name',)
-    inlines = (ChannelInline,)
+    inlines = (CharacterInline, ChannelInline,)
     formfield_overrides = {
         HTMLField: {'widget': TinyMCE(mce_attrs={'theme': 'advanced'})},
     }

--- a/ahgl/api/migrations/0018_auto__add_character__add_field_game_home_character_diplay_name__add_fi.py
+++ b/ahgl/api/migrations/0018_auto__add_character__add_field_game_home_character_diplay_name__add_fi.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Character'
+        db.create_table('api_character', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('game', self.gf('django.db.models.fields.related.ForeignKey')(related_name='options', to=orm['api.Game'])),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+        ))
+        db.send_create_signal('api', ['Character'])
+
+        # Adding field 'Game.home_character_diplay_name'
+        db.add_column('api_game', 'home_character_diplay_name',
+                      self.gf('django.db.models.fields.CharField')(default='Home Race', max_length=2048),
+                      keep_default=False)
+
+        # Adding field 'Game.away_character_diplay_name'
+        db.add_column('api_game', 'away_character_diplay_name',
+                      self.gf('django.db.models.fields.CharField')(default='Away Race', max_length=2048),
+                      keep_default=False)
+
+        # Adding field 'Game.character_number'
+        db.add_column('api_game', 'character_number',
+                      self.gf('django.db.models.fields.PositiveIntegerField')(default=1),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting model 'Character'
+        db.delete_table('api_character')
+
+        # Deleting field 'Game.home_character_diplay_name'
+        db.delete_column('api_game', 'home_character_diplay_name')
+
+        # Deleting field 'Game.away_character_diplay_name'
+        db.delete_column('api_game', 'away_character_diplay_name')
+
+        # Deleting field 'Game.character_number'
+        db.delete_column('api_game', 'character_number')
+
+
+    models = {
+        'api.carouselitem': {
+            'Meta': {'object_name': 'CarouselItem'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'message': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'tournaments': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'carousel_items'", 'symmetrical': 'False', 'to': "orm['tournaments.Tournament']"})
+        },
+        'api.channel': {
+            'Meta': {'object_name': 'Channel'},
+            'game': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'channel_names'", 'to': "orm['api.Game']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'primary': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'api.character': {
+            'Meta': {'object_name': 'Character'},
+            'game': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'options'", 'to': "orm['api.Game']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'api.game': {
+            'Meta': {'object_name': 'Game'},
+            'article_section_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'away_character_diplay_name': ('django.db.models.fields.CharField', [], {'default': "'Away Race'", 'max_length': '2048'}),
+            'background_match_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'character_number': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'header_image_glow_hex_color': ('api.fields.ColourField', [], {'max_length': '7'}),
+            'header_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'home_character_diplay_name': ('django.db.models.fields.CharField', [], {'default': "'Home Race'", 'max_length': '2048'}),
+            'icon_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'live_stream_section_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'match_section_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'questions': ('profiles.fields.HTMLField', [], {'default': "'<ol><li>\\n<p>Why did you choose this race/champion?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>What do you do for a living?  What do you love about your job?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>What other hobbies do you have?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>Why do you play StarCraft/League of Legends?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>How long have you been playing?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>What have you done to prepare for the momentous challenge that is the AHGL Tournament?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>Why is your team going to win?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>Who is the best player on your team?  Why?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>Whom do you fear most amongst the competition and why?</p>\\n<p>-</p>\\n</li>\\n</ol>'", 'attributes': "{'blockquote': ['cite'], 'th': ['colspan'], 'table': ['class'], 'td': ['colspan'], 'a': ['href', 'rel', 'target', 'title', 'data-toggle', 'class'], 'span': ['class'], 'img': ['src', 'alt', 'title', 'style'], 'ul': ['class'], 'li': ['class'], 'q': ['cite'], 'p': ['style'], 'iframe': ['src', 'width', 'height', 'frameborder', 'allowfullscreen'], 'div': ['class', 'id', 'style']}", 'blank': 'True', 'tags': "['ol', 'ul', 'li', 'strong', 'em', 'p']"}),
+            'small_game_thumbnail': ('django.db.models.fields.CharField', [], {'max_length': '2048'})
+        },
+        'tournaments.map': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Map'},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'primary_key': 'True'}),
+            'photo': ('sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'})
+        },
+        'tournaments.tournament': {
+            'Meta': {'object_name': 'Tournament'},
+            'game': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['api.Game']", 'unique': 'True', 'null': 'True'}),
+            'games_per_match': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '5'}),
+            'map_pool': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['tournaments.Map']", 'symmetrical': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'S'", 'max_length': '1', 'db_index': 'True'}),
+            'structure': ('django.db.models.fields.CharField', [], {'default': "'I'", 'max_length': '1'})
+        }
+    }
+
+    complete_apps = ['api']

--- a/ahgl/api/models.py
+++ b/ahgl/api/models.py
@@ -62,6 +62,10 @@ class Game(models.Model):
 </li>
 </ol>""")
 
+    home_character_diplay_name = models.CharField(max_length=2048, default="Home Race")
+    away_character_diplay_name = models.CharField(max_length=2048, default="Away Race")
+    character_number = models.PositiveIntegerField(default=1)
+
     objects = GameManager()
 
 
@@ -82,7 +86,13 @@ class Game(models.Model):
             return ""
 
         return channels[0].name
-        
+     
+class Character(models.Model):
+    game = models.ForeignKey('Game', related_name='options')
+    name = models.CharField(max_length=100)
+
+    def __unicode__(self):
+        return self.name
 
 class Channel(models.Model):
     name = models.CharField(max_length=100)

--- a/ahgl/tournaments/forms.py
+++ b/ahgl/tournaments/forms.py
@@ -4,6 +4,8 @@ from .models import Match, Game
 from api.models import Character
 from django.forms import ModelForm, ModelChoiceField
 
+from django.utils.translation import ugettext_lazy as _
+
 
 class BaseMatchFormSet(BaseModelFormSet):
     def __init__(self, *args, **kwargs):
@@ -51,13 +53,26 @@ class MultipleFormSetBase(object):
 
 class GameForm(ModelForm):
     """Form for adding and editing games."""
-    
-    def __init__(self, *args, **kwargs):
-        super(GameForm,self).__init__(*args,**kwargs)
-        # TODO: For some reason accessing self.instance raises some issues
-        if self.instance:
-            self.fields['home_race'].label = self.instance.tournament.game.home_character_diplay_name
-            self.fields['away_race'].label = self.instance.tournament.game.away_character_diplay_name
+
+    def clean(self):
+        super(GameForm, self).clean()
+        from django.core.exceptions import ValidationError
+        match = self.cleaned_data.get('match')
+        home_race = self.cleaned_data.get('home_race')
+        away_race = self.cleaned_data.get('away_race')
+
+        if match:
+            if home_race and home_race:
+                # Check that the number of selected characters match to the character_number from api.Game
+                if home_race.count() != match.tournament.game.character_number or away_race.count() != match.tournament.game.character_number:
+                    raise ValidationError(_('Please, select %d characters for %s and %s fields') 
+                        % (match.tournament.game.character_number, 
+                            match.tournament.game.home_character_diplay_name, 
+                            match.tournament.game.away_character_diplay_name))
+
+        return self.cleaned_data
 
     class Meta:
         model = Game
+        fields = ('map', 'order', 'home_player', 'home_race', 'away_player', 'away_race', 'winner', 
+            'winner_team', 'forfeit', 'replay', 'vod', 'is_ace', 'victory_screen',)

--- a/ahgl/tournaments/forms.py
+++ b/ahgl/tournaments/forms.py
@@ -56,8 +56,8 @@ class GameForm(ModelForm):
         super(GameForm,self).__init__(*args,**kwargs)
         # TODO: For some reason accessing self.instance raises some issues
         if self.instance:
-            self.fields['home_race'].label = self.instance.match.tournament.game.home_character_diplay_name
-            self.fields['away_race'].label = self.instance.match.tournament.game.away_character_diplay_name
+            self.fields['home_race'].label = self.instance.tournament.game.home_character_diplay_name
+            self.fields['away_race'].label = self.instance.tournament.game.away_character_diplay_name
 
     class Meta:
         model = Game

--- a/ahgl/tournaments/forms.py
+++ b/ahgl/tournaments/forms.py
@@ -1,6 +1,8 @@
 from django.forms.models import BaseModelFormSet
 
-from .models import Match
+from .models import Match, Game
+from api.models import Character
+from django.forms import ModelForm, ModelChoiceField
 
 
 class BaseMatchFormSet(BaseModelFormSet):
@@ -46,3 +48,16 @@ class MultipleFormSetBase(object):
     def save(self, commit=True):
         return tuple(form.save(commit) for form in self.forms if hasattr(form, "save"))
     save.alters_data = True
+
+class GameForm(ModelForm):
+    """Form for adding and editing games."""
+    
+    def __init__(self, *args, **kwargs):
+        super(GameForm,self).__init__(*args,**kwargs)
+        # TODO: For some reason accessing self.instance raises some issues
+        if self.instance:
+            self.fields['home_race'].label = self.instance.match.tournament.game.home_character_diplay_name
+            self.fields['away_race'].label = self.instance.match.tournament.game.away_character_diplay_name
+
+    class Meta:
+        model = Game

--- a/ahgl/tournaments/forms.py
+++ b/ahgl/tournaments/forms.py
@@ -62,12 +62,16 @@ class GameForm(ModelForm):
         away_race = self.cleaned_data.get('away_race')
 
         if match:
-            if home_race and home_race:
-                # Check that the number of selected characters match to the character_number from api.Game
-                if home_race.count() != match.tournament.game.character_number or away_race.count() != match.tournament.game.character_number:
-                    raise ValidationError(_('Please, select %d characters for %s and %s fields') 
+            if home_race:
+                if home_race.count() != match.tournament.game.character_number:
+                    raise ValidationError(_('Please, select %d characters for %s field') 
                         % (match.tournament.game.character_number, 
-                            match.tournament.game.home_character_diplay_name, 
+                            match.tournament.game.home_character_diplay_name))
+
+            if away_race:
+                if away_race.count() != match.tournament.game.character_number:
+                    raise ValidationError(_('Please, select %d characters for %s field') 
+                        % (match.tournament.game.character_number,
                             match.tournament.game.away_character_diplay_name))
 
         return self.cleaned_data

--- a/ahgl/tournaments/migrations/0053_auto__del_field_game_home_race__del_field_game_away_race.py
+++ b/ahgl/tournaments/migrations/0053_auto__del_field_game_home_race__del_field_game_away_race.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Game.home_race'
+        db.delete_column('tournaments_game', 'home_race')
+
+        # Deleting field 'Game.away_race'
+        db.delete_column('tournaments_game', 'away_race')
+
+        # Adding M2M table for field home_race on 'Game'
+        db.create_table('tournaments_game_home_race', (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('game', models.ForeignKey(orm['tournaments.game'], null=False)),
+            ('character', models.ForeignKey(orm['api.character'], null=False))
+        ))
+        db.create_unique('tournaments_game_home_race', ['game_id', 'character_id'])
+
+        # Adding M2M table for field away_race on 'Game'
+        db.create_table('tournaments_game_away_race', (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('game', models.ForeignKey(orm['tournaments.game'], null=False)),
+            ('character', models.ForeignKey(orm['api.character'], null=False))
+        ))
+        db.create_unique('tournaments_game_away_race', ['game_id', 'character_id'])
+
+
+    def backwards(self, orm):
+        # Adding field 'Game.home_race'
+        db.add_column('tournaments_game', 'home_race',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=1, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Game.away_race'
+        db.add_column('tournaments_game', 'away_race',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=1, blank=True),
+                      keep_default=False)
+
+        # Removing M2M table for field home_race on 'Game'
+        db.delete_table('tournaments_game_home_race')
+
+        # Removing M2M table for field away_race on 'Game'
+        db.delete_table('tournaments_game_away_race')
+
+
+    models = {
+        'api.character': {
+            'Meta': {'object_name': 'Character'},
+            'game': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'options'", 'to': "orm['api.Game']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'api.game': {
+            'Meta': {'object_name': 'Game'},
+            'article_section_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'away_character_diplay_name': ('django.db.models.fields.CharField', [], {'default': "'Away Race'", 'max_length': '2048'}),
+            'background_match_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'character_number': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'header_image_glow_hex_color': ('api.fields.ColourField', [], {'max_length': '7'}),
+            'header_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'home_character_diplay_name': ('django.db.models.fields.CharField', [], {'default': "'Home Race'", 'max_length': '2048'}),
+            'icon_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'live_stream_section_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'match_section_image_url': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'questions': ('profiles.fields.HTMLField', [], {'default': "'<ol><li>\\n<p>Why did you choose this race/champion?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>What do you do for a living?  What do you love about your job?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>What other hobbies do you have?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>Why do you play StarCraft/League of Legends?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>How long have you been playing?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>What have you done to prepare for the momentous challenge that is the AHGL Tournament?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>Why is your team going to win?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>Who is the best player on your team?  Why?</p>\\n<p>-</p>\\n</li>\\n<li>\\n<p>Whom do you fear most amongst the competition and why?</p>\\n<p>-</p>\\n</li>\\n</ol>'", 'attributes': "{'blockquote': ['cite'], 'th': ['colspan'], 'table': ['class'], 'td': ['colspan'], 'a': ['href', 'rel', 'target', 'title', 'data-toggle', 'class'], 'span': ['class'], 'img': ['src', 'alt', 'title', 'style'], 'ul': ['class'], 'li': ['class'], 'q': ['cite'], 'p': ['style'], 'iframe': ['src', 'width', 'height', 'frameborder', 'allowfullscreen'], 'div': ['class', 'id', 'style']}", 'blank': 'True', 'tags': "['ol', 'ul', 'li', 'strong', 'em', 'p']"}),
+            'small_game_thumbnail': ('django.db.models.fields.CharField', [], {'max_length': '2048'})
+        },
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 12, 6, 0, 0)'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'profiles.charity': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Charity'},
+            'desc': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'logo': ('sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '60'})
+        },
+        'profiles.profile': {
+            'Meta': {'object_name': 'Profile'},
+            'autosubscribe': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'avatar': ('sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'custom_thumb': ('sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'default': "'en'", 'max_length': '10', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'photo': ('sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'post_count': ('django.db.models.fields.IntegerField', [], {'default': '0', 'blank': 'True'}),
+            'show_signatures': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'signature': ('django.db.models.fields.TextField', [], {'max_length': '1024', 'blank': 'True'}),
+            'signature_html': ('django.db.models.fields.TextField', [], {'max_length': '1054', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'time_zone': ('django.db.models.fields.FloatField', [], {'default': '3.0'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '70', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'profile'", 'to': "orm['auth.User']"}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'profiles.team': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('name', 'tournament'), ('slug', 'tournament'))", 'object_name': 'Team'},
+            'approval': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'charity': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'teams'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['profiles.Charity']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'karma': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'losses': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'teams'", 'to': "orm['profiles.Profile']", 'through': "orm['profiles.TeamMembership']", 'blank': 'True', 'symmetrical': 'False', 'null': 'True'}),
+            'motto': ('django.db.models.fields.CharField', [], {'max_length': '70', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '35'}),
+            'paid': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'photo': ('sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'seed': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'R'", 'max_length': '1'}),
+            'tiebreaker': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'tournament': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'teams'", 'to': "orm['tournaments.Tournament']"}),
+            'wins': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'profiles.teammembership': {
+            'Meta': {'ordering': "('-active', '-captain', 'char_name')", 'unique_together': "(('team', 'profile'),)", 'object_name': 'TeamMembership', 'db_table': "'profiles_team_members'"},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'captain': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'champion': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'char_code': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'char_name': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'game_profile': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'profile': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'team_membership'", 'to': "orm['profiles.Profile']"}),
+            'questions_answers': ('profiles.fields.HTMLField', [], {'attributes': "{'blockquote': ['cite'], 'th': ['colspan'], 'table': ['class'], 'td': ['colspan'], 'a': ['href', 'rel', 'target', 'title', 'data-toggle', 'class'], 'span': ['class'], 'img': ['src', 'alt', 'title', 'style'], 'ul': ['class'], 'li': ['class'], 'q': ['cite'], 'p': ['style'], 'iframe': ['src', 'width', 'height', 'frameborder', 'allowfullscreen'], 'div': ['class', 'id', 'style']}", 'blank': 'True', 'tags': "['ol', 'ul', 'li', 'strong', 'em', 'p']"}),
+            'race': ('django.db.models.fields.CharField', [], {'max_length': '1', 'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'A'", 'max_length': '1'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'team_membership'", 'to': "orm['profiles.Team']"})
+        },
+        'tournaments.article': {
+            'Meta': {'object_name': 'Article'},
+            'creation_date': ('django.db.models.fields.DateField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'publish_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'summary': ('tinymce.models.HTMLField', [], {'max_length': '4000', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'tournaments': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'articles'", 'symmetrical': 'False', 'to': "orm['tournaments.Tournament']"})
+        },
+        'tournaments.articlepluginmodel': {
+            'Meta': {'object_name': 'ArticlePluginModel', 'db_table': "'cmsplugin_articlepluginmodel'", '_ormbases': ['cms.CMSPlugin']},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'cms_plugin'", 'unique': 'True', 'to': "orm['tournaments.Article']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tournaments.game': {
+            'Meta': {'ordering': "('order',)", 'unique_together': "(('order', 'match'),)", 'object_name': 'Game'},
+            'away_player': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'away_games'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['profiles.TeamMembership']"}),
+            'away_race': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'match_away_games'", 'blank': 'True', 'to': "orm['api.Character']"}),
+            'forfeit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'home_player': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'home_games'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['profiles.TeamMembership']"}),
+            'home_race': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'match_home_games'", 'blank': 'True', 'to': "orm['api.Character']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_ace': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'loser': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'game_losses'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['profiles.TeamMembership']"}),
+            'loser_team': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'game_losses'", 'null': 'True', 'to': "orm['profiles.Team']"}),
+            'map': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tournaments.Map']"}),
+            'match': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'games'", 'to': "orm['tournaments.Match']"}),
+            'order': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'replay': ('django.db.models.fields.files.FileField', [], {'max_length': '300', 'null': 'True', 'blank': 'True'}),
+            'victory_screen': ('django.db.models.fields.files.ImageField', [], {'max_length': '300', 'null': 'True', 'blank': 'True'}),
+            'vod': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'winner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'game_wins'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['profiles.TeamMembership']"}),
+            'winner_team': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'game_wins'", 'null': 'True', 'to': "orm['profiles.Team']"})
+        },
+        'tournaments.gamepluginmodel': {
+            'Meta': {'object_name': 'GamePluginModel', 'db_table': "'cmsplugin_gamepluginmodel'", '_ormbases': ['cms.CMSPlugin']},
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'game': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tournaments.Game']", 'null': 'True', 'blank': 'True'}),
+            'tournament': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tournaments.Tournament']"})
+        },
+        'tournaments.map': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Map'},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'primary_key': 'True'}),
+            'photo': ('sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'})
+        },
+        'tournaments.match': {
+            'Meta': {'object_name': 'Match'},
+            'away_submission_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'away_submitted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'away_team': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'away_matches'", 'to': "orm['profiles.Team']"}),
+            'creation_date': ('django.db.models.fields.DateField', [], {}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'home_submission_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'home_submitted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'home_team': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'home_matches'", 'to': "orm['profiles.Team']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'loser': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'match_losses'", 'null': 'True', 'to': "orm['profiles.Team']"}),
+            'publish_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'referee': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['profiles.Profile']", 'null': 'True', 'blank': 'True'}),
+            'structure': ('django.db.models.fields.CharField', [], {'default': "'I'", 'max_length': '1'}),
+            'tournament': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'matches'", 'to': "orm['tournaments.Tournament']"}),
+            'tournament_round': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'matches'", 'to': "orm['tournaments.TournamentRound']"}),
+            'winner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'match_wins'", 'null': 'True', 'to': "orm['profiles.Team']"})
+        },
+        'tournaments.tournament': {
+            'Meta': {'object_name': 'Tournament'},
+            'game': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['api.Game']", 'unique': 'True', 'null': 'True'}),
+            'games_per_match': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '5'}),
+            'map_pool': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['tournaments.Map']", 'symmetrical': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'S'", 'max_length': '1', 'db_index': 'True'}),
+            'structure': ('django.db.models.fields.CharField', [], {'default': "'I'", 'max_length': '1'})
+        },
+        'tournaments.tournamentpluginmodel': {
+            'Meta': {'object_name': 'TournamentPluginModel', 'db_table': "'cmsplugin_tournamentpluginmodel'", '_ormbases': ['cms.CMSPlugin']},
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'tournament': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tournaments.Tournament']"})
+        },
+        'tournaments.tournamentround': {
+            'Meta': {'ordering': "('-stage_order', 'order')", 'object_name': 'TournamentRound'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'stage_name': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'stage_order': ('django.db.models.fields.IntegerField', [], {}),
+            'structure': ('django.db.models.fields.CharField', [], {'default': "'G'", 'max_length': '1'}),
+            'teams': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'rounds'", 'symmetrical': 'False', 'to': "orm['profiles.Team']"}),
+            'tournament': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'rounds'", 'to': "orm['tournaments.Tournament']"})
+        }
+    }
+
+    complete_apps = ['tournaments']

--- a/ahgl/tournaments/models.py
+++ b/ahgl/tournaments/models.py
@@ -353,9 +353,9 @@ class Game(models.Model):
     map = models.ForeignKey('Map')  # add verification that this is in map pool for tournament
     order = models.PositiveSmallIntegerField()
     home_player = models.ForeignKey('profiles.TeamMembership', related_name="home_games", null=True, blank=True, on_delete=models.SET_NULL)
-    home_race = models.ManyToManyField('api.Character', blank=True, related_name="match_home_games")
+    home_race = models.ManyToManyField('api.Character', blank=True, null=True, related_name="match_home_games")
     away_player = models.ForeignKey('profiles.TeamMembership', related_name="away_games", null=True, blank=True, on_delete=models.SET_NULL)
-    away_race = models.ManyToManyField('api.Character', blank=True, related_name="match_away_games")
+    away_race = models.ManyToManyField('api.Character', blank=True, null=True, related_name="match_away_games")
     winner = models.ForeignKey('profiles.TeamMembership', related_name="game_wins", blank=True, null=True, on_delete=models.SET_NULL)
     loser = models.ForeignKey('profiles.TeamMembership', related_name="game_losses", blank=True, null=True, editable=False, on_delete=models.SET_NULL)
     winner_team = models.ForeignKey('profiles.Team', related_name="game_wins", blank=True, null=True)

--- a/ahgl/tournaments/models.py
+++ b/ahgl/tournaments/models.py
@@ -433,6 +433,19 @@ class Game(models.Model):
                 self.match.full_clean()
                 self.match.save()
 
+    def get_comma_separated_characters(self, characters):
+        races = []
+        for character in characters:
+            races.append(character.name)
+
+        return ", ".join(races)
+
+    def get_home_races(self):
+        return self.get_comma_separated_characters(self.home_race.all())
+
+    def get_away_races(self):
+        return self.get_comma_separated_characters(self.away_race.all())
+
     def __unicode__(self):
         if self.home_player and self.away_player:
             ret = u" vs ".join((unicode(self.home_player), unicode(self.away_player)))

--- a/ahgl/tournaments/models.py
+++ b/ahgl/tournaments/models.py
@@ -353,9 +353,9 @@ class Game(models.Model):
     map = models.ForeignKey('Map')  # add verification that this is in map pool for tournament
     order = models.PositiveSmallIntegerField()
     home_player = models.ForeignKey('profiles.TeamMembership', related_name="home_games", null=True, blank=True, on_delete=models.SET_NULL)
-    home_race = models.CharField(max_length=1, choices=RACES, blank=True)  # TODO: default to player's race in UI
+    home_race = models.ManyToManyField('api.Character', blank=True, related_name="match_home_games")
     away_player = models.ForeignKey('profiles.TeamMembership', related_name="away_games", null=True, blank=True, on_delete=models.SET_NULL)
-    away_race = models.CharField(max_length=1, choices=RACES, blank=True)  # TODO: default to player's race in UI
+    away_race = models.ManyToManyField('api.Character', blank=True, related_name="match_away_games")
     winner = models.ForeignKey('profiles.TeamMembership', related_name="game_wins", blank=True, null=True, on_delete=models.SET_NULL)
     loser = models.ForeignKey('profiles.TeamMembership', related_name="game_losses", blank=True, null=True, editable=False, on_delete=models.SET_NULL)
     winner_team = models.ForeignKey('profiles.Team', related_name="game_wins", blank=True, null=True)

--- a/ahgl/tournaments/models.py
+++ b/ahgl/tournaments/models.py
@@ -438,7 +438,7 @@ class Game(models.Model):
         for character in characters:
             races.append(character.name)
 
-        return ", ".join(races)
+        return races
 
     def get_home_races(self):
         return self.get_comma_separated_characters(self.home_race.all())

--- a/ahgl/tournaments/templates/tournaments/game_detail.html
+++ b/ahgl/tournaments/templates/tournaments/game_detail.html
@@ -27,7 +27,7 @@
 </a>
 {% endif %}
 <p></p>
-<h3 class="t3">Game {{game.order}} – {{game.map}}{% if match.home_submitted and match.away_submitted and game.home_race %} – {{game.home_race}}v{{game.away_race}}{% endif %}</h3>
+<h3 class="t3">Game {{game.order}} – {{game.map}}</h3>
 {% if game.replay %}
 <p><a href="{{ MEDIA_URL }}{{game.replay}}">Get the replay</a></p>
 {% endif %}

--- a/ahgl/tournaments/templates/tournaments/player_admin.html
+++ b/ahgl/tournaments/templates/tournaments/player_admin.html
@@ -23,9 +23,9 @@ Player Admin
       {% if game.is_ace or not game.home_player %}
         <td colspan="3">{% if game.is_ace %}ACE{% endif %}</td>
       {% else %}
-        <td><a href="{{game.home_player.get_absolute_url}}">{{game.home_player}}.{{game.home_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_home_race_display}}</td>
+        <td><a href="{{game.home_player.get_absolute_url}}">{{game.home_player}}.{{game.home_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_home_races}}</td>
         <td>vs</td>
-        <td><a href="{{game.away_player.get_absolute_url}}">{{game.away_player}}.{{game.away_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_away_race_display}}</td>
+        <td><a href="{{game.away_player.get_absolute_url}}">{{game.away_player}}.{{game.away_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_away_races}}</td>
       {% endif %}
     {% endfor %}
     </table>

--- a/ahgl/tournaments/templates/tournaments/player_admin.html
+++ b/ahgl/tournaments/templates/tournaments/player_admin.html
@@ -23,9 +23,9 @@ Player Admin
       {% if game.is_ace or not game.home_player %}
         <td colspan="3">{% if game.is_ace %}ACE{% endif %}</td>
       {% else %}
-        <td><a href="{{game.home_player.get_absolute_url}}">{{game.home_player}}.{{game.home_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_home_races}}</td>
+        <td><a href="{{game.home_player.get_absolute_url}}">{{game.home_player}}.{{game.home_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_home_races|join:", "}}</td>
         <td>vs</td>
-        <td><a href="{{game.away_player.get_absolute_url}}">{{game.away_player}}.{{game.away_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_away_races}}</td>
+        <td><a href="{{game.away_player.get_absolute_url}}">{{game.away_player}}.{{game.away_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_away_races|join:", "}}</td>
       {% endif %}
     {% endfor %}
     </table>

--- a/ahgl/tournaments/templates/tournaments/report_match.html
+++ b/ahgl/tournaments/templates/tournaments/report_match.html
@@ -16,7 +16,7 @@
         {% for f in part %}
         <fieldset>
             <legend class="row-fluid"><div class="span2">{{forloop.counter}}) {{f.instance.map}}</div>
-            {% if f.instance.home_player %}<div class="span">{% if not f.instance.is_ace %}{{f.instance.home_player}} ({{f.instance.get_home_race_display}}) vs {{f.instance.away_player}} ({{f.instance.get_away_race_display}}){% endif %}</div>{% endif %}
+            {% if f.instance.home_player %}<div class="span">{% if not f.instance.is_ace %}{{f.instance.home_player}} ({{f.instance.get_home_races}}) vs {{f.instance.away_player}} ({{f.instance.get_away_races}}){% endif %}</div>{% endif %}
             </legend>
             {{ f|as_bootstrap }}
         </fieldset>

--- a/ahgl/tournaments/templates/tournaments/report_match.html
+++ b/ahgl/tournaments/templates/tournaments/report_match.html
@@ -16,7 +16,7 @@
         {% for f in part %}
         <fieldset>
             <legend class="row-fluid"><div class="span2">{{forloop.counter}}) {{f.instance.map}}</div>
-            {% if f.instance.home_player %}<div class="span">{% if not f.instance.is_ace %}{{f.instance.home_player}} ({{f.instance.get_home_races}}) vs {{f.instance.away_player}} ({{f.instance.get_away_races}}){% endif %}</div>{% endif %}
+            {% if f.instance.home_player %}<div class="span">{% if not f.instance.is_ace %}{{f.instance.home_player}} ({{f.instance.get_home_races|join:", "}}) vs {{f.instance.away_player}} ({{f.instance.get_away_races|join:", "}}){% endif %}</div>{% endif %}
             </legend>
             {{ f|as_bootstrap }}
         </fieldset>

--- a/ahgl/tournaments/templates/tournaments/view_lineup.html
+++ b/ahgl/tournaments/templates/tournaments/view_lineup.html
@@ -23,9 +23,9 @@
     {% if game.is_ace %}
     <td>ACE</td><td></td><td></td>
     {% else %}
-    <td><a href="{{game.home_player.get_absolute_url}}">{{game.home_player}}.{{game.home_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_home_races}}</td>
+    <td><a href="{{game.home_player.get_absolute_url}}">{{game.home_player}}.{{game.home_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_home_races|join:", "}}</td>
     <td>vs</td>
-    <td><a href="{{game.away_player.get_absolute_url}}">{{game.get_away_races}}.{{game.away_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_away_race_display}}</td>
+    <td><a href="{{game.away_player.get_absolute_url}}">{{game.get_away_races|join:", "}}.{{game.away_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_away_race_display}}</td>
     {% endif %}
     {% endfor %}
     </table>

--- a/ahgl/tournaments/templates/tournaments/view_lineup.html
+++ b/ahgl/tournaments/templates/tournaments/view_lineup.html
@@ -23,9 +23,9 @@
     {% if game.is_ace %}
     <td>ACE</td><td></td><td></td>
     {% else %}
-    <td><a href="{{game.home_player.get_absolute_url}}">{{game.home_player}}.{{game.home_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_home_race_display}}</td>
+    <td><a href="{{game.home_player.get_absolute_url}}">{{game.home_player}}.{{game.home_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_home_races}}</td>
     <td>vs</td>
-    <td><a href="{{game.away_player.get_absolute_url}}">{{game.away_player}}.{{game.away_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_away_race_display}}</td>
+    <td><a href="{{game.away_player.get_absolute_url}}">{{game.get_away_races}}.{{game.away_player.char_code|default_if_none:"xxx"}}</a> as {{game.get_away_race_display}}</td>
     {% endif %}
     {% endfor %}
     </table>

--- a/ahgl/tournaments/views.py
+++ b/ahgl/tournaments/views.py
@@ -121,6 +121,7 @@ class NewTournamentRoundView(TemplateResponseMixin, FormMixin, ProcessFormView):
                             for i, map_form in enumerate(map_formset, start=1):
                                 if 'map' in map_form.cleaned_data and map_form.cleaned_data['map']:
                                     match_form.instance.games.create(order=i, **map_form.cleaned_data)
+
                 return ret
         return NewTournamentRoundForm
 
@@ -384,28 +385,30 @@ class SubmitLineupView(ObjectPermissionsCheckMixin, UpdateView):
         return context
 
     def get_form_class(self):
+        team = self.team
+        match = self.object
         if self.home_team:
             side = "home"
+            race_label = match.tournament.game.home_character_diplay_name
         else:
             side = "away"
-        queryset = TeamMembership.objects.filter(team=self.team, active=True)
-        if self.team.tournament.structure == "I":
-            queryset = queryset.filter(char_code__isnull=False)
-        player = forms.ModelChoiceField(queryset=queryset, label='Player')
-        race = forms.ChoiceField(label='Race',
-                                 choices=[('', '---------')] + list(RACES))
-        namespace = {
-            'base_fields': {
-                side + '_player': player,
-                side + '_race': race
-            },
-            '_meta': ModelFormOptions({
-                'model': Game,
-                'fields': (side + '_player', side + '_race')
-            })
-        }
-        form = type('SubmitLineupForm', (BaseModelForm,), namespace)
-        return inlineformset_factory(Match, Game, extra=0, can_delete=False, form=form)
+            race_label = match.tournament.game.away_character_diplay_name
+
+        class SubmitLineupForm(GameForm):
+            def __init__(self, *args, **kwargs):
+                super(SubmitLineupForm, self).__init__(*args, **kwargs)
+
+                queryset = TeamMembership.objects.filter(team=team, active=True)
+
+                self.fields[side + '_player'] = forms.ModelChoiceField(queryset=TeamMembership.objects.filter(team=team, active=True),
+                                                                        label='%s Player' % (side.title()))
+                self.fields[side + '_race'] = forms.ModelMultipleChoiceField(queryset=Character.objects.filter(game=match.tournament.game),
+                                                                              label=race_label)
+            class Meta:
+                model = Game
+                fields = (side + '_player', side + '_race')
+
+        return inlineformset_factory(Match, Game, extra=0, can_delete=False, form=SubmitLineupForm)
 
     def form_valid(self, *args, **kwargs):
         if self.home_team:

--- a/ahgl/tournaments/views.py
+++ b/ahgl/tournaments/views.py
@@ -34,6 +34,9 @@ from profiles.views import TournamentSlugContextView
 from .models import Tournament, Match, Game, TournamentRound
 from .forms import BaseMatchFormSet, MultipleFormSetBase
 
+from api.models import Character
+from .forms import GameForm
+
 logger = logging.getLogger(__name__)
 
 
@@ -285,7 +288,7 @@ class MatchReportView(UpdateView):
     def get_form_class(self):
         match = self.object
         if match.structure == "I":
-            class ReportMatchForm(ModelForm):
+            class ReportMatchForm(GameForm):
                 winner = forms.ModelChoiceField(required=False,
                                                 queryset=TeamMembership.objects.all(),
                                                 widget=forms.RadioSelect,
@@ -310,6 +313,12 @@ class MatchReportView(UpdateView):
                                                                        queryset=TeamMembership.objects.filter(active=True, team__pk__in=(match.home_team_id, match.away_team_id,)),
                                                                        empty_label="Not played"
                                                                        )
+                        self.fields['home_race'] = forms.ModelMultipleChoiceField(required=False,
+                                                                                  queryset=Character.objects.filter(game=match.tournament.game),
+                                                                                  label=match.tournament.game.home_character_diplay_name)
+                        self.fields['away_race'] = forms.ModelMultipleChoiceField(required=False,
+                                                                                  queryset=Character.objects.filter(game=match.tournament.game),
+                                                                                  label=match.tournament.game.away_character_diplay_name)
 
                 class Meta:
                     model = Game


### PR DESCRIPTION
This PR is done and ready to be pushed to staging.

Based on the #125 feature we have the following tasks:

Task 1 (DONE): Add new fields to the api.Game model.
     'Character Selection Display Name' of both fields (e.g. 'Home Race', 'Away Race)
     'Character Selection Options' users can select from (this is a list of strings)
     'Number of Character Selections' - the number of items that must be selected 

Task 2 (DONE): Alter the home_race and away_race in tournament.Game to allow to select more than one race.

Task 3 (DONE): For the frontend match page (e.g. http://afterhoursgaming.tv/starcraft-2-season-5/matches/2080/), it currently has special logic to take the Home and Away Race and post things like 'TvP' that depend on both selections. Simply remove this code, and don't display anything related to this field on the frontend match page.

Task 4 (DONE): For the player admin: http://afterhoursgaming.tv/player_admin/ page, display all selectied option, comma separated.

Task 5 (DONE): Use the api.game.home_character_display_name and api.Game.away_character_display_name to make the headers of tournaments.game.home_race and tournaments.game.away_race field headers dynamic.

Task 6 and 7 (DONE): Add validation based on the api.game.number_of_character_selection number to force users to select exact number of races for home and away race fields in the ADMIN and FRONTEND pages.
     
