### PR TITLE
Update wiredep dependencies

### DIFF
--- a/ahgl/static/js/app/Gruntfile.js
+++ b/ahgl/static/js/app/Gruntfile.js
@@ -210,7 +210,9 @@ module.exports = function (grunt) {
         // Automatically inject Bower components into the app
         wiredep: {
             options: {
-                cwd: '<%= yeoman.app %>'
+                cwd: '<%= yeoman.app %>',
+                bowerJson: 'bower.json',
+                directory: 'bower_components'
             },
             app: {
                 src: ['<%= yeoman.app %>/*.html'],

--- a/ahgl/static/js/app/app/head.html
+++ b/ahgl/static/js/app/app/head.html
@@ -1,8 +1,8 @@
 <!-- This is also used by Django templates to inlclude the new Angular app. -->
 
 <!-- build:css(.) styles/vendor.css -->
-<!-- bower:css -->
 <link rel="stylesheet" href="bower_components/angular-carousel/dist/angular-carousel.css" />
+<!-- bower:css -->
 <!-- endbower -->
 <!-- endbuild -->
 
@@ -18,7 +18,6 @@
 <!-- endbuild -->
 
 <!-- build:js(.) scripts/vendor.js -->
-<!-- bower:js -->
 <script src="bower_components/angular/angular.js"></script>
 <script src="bower_components/json3/lib/json3.js"></script>
 <script src="bower_components/angular-resource/angular-resource.js"></script>
@@ -29,6 +28,7 @@
 <script src="bower_components/angular-route/angular-route.js"></script>
 <script src="bower_components/angular-carousel/dist/angular-carousel.js"></script>
 <script src="bower_components/underscore/underscore.js"></script>
+<!-- bower:js -->
 <!-- endbower -->
 <!-- endbuild -->
 


### PR DESCRIPTION
This is pretty strange but the new version of wiredep requires the listing of dependencies outside of bower:js block. 

If left in its current spot, upon running wiredep task would remove the references listed in the block. 